### PR TITLE
Update pom.xml

### DIFF
--- a/beer_contracts/pom.xml
+++ b/beer_contracts/pom.xml
@@ -62,7 +62,7 @@
 				<executions>
 					<execution>
 						<id>contracts</id>
-						<phase>prepare-package</phase>
+						<phase>package</phase>
 						<goals>
 							<goal>single</goal>
 						</goals>


### PR DESCRIPTION
The plugin was bound to the prepare-package phase, but on some windows machines the resulting jar does contain a lot more then the resources that are specified in the contracts.xml (which has some exclusions in our case).
It seems that mvn overwrites the correctly generated jar with a default mvn jar. When setting the <appendAssemblyId> to true the difference is clear. The "[abc]-project.jar" contains only the correctly filtered resources from the contracts.xml and the [abc].jar contains all resources.
Now the plugin is bound to the package phase and now even with the <appendAssemblyId> set to false the correct jar is produced.